### PR TITLE
John

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb filter=nbstripout 

--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,3 @@ __pycache__/
 **/*.html
 
 # Clear notebook outputs
-*.ipynb filter=strip-notebook-output

--- a/Search_tester.ipynb
+++ b/Search_tester.ipynb
@@ -26,120 +26,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 57,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Requirement already satisfied: numpy in ./.venv/lib/python3.13/site-packages (from -r requirements.txt (line 1)) (2.2.3)\n",
-      "Requirement already satisfied: tqdm in ./.venv/lib/python3.13/site-packages (from -r requirements.txt (line 2)) (4.67.1)\n",
-      "Requirement already satisfied: pillow in ./.venv/lib/python3.13/site-packages (from -r requirements.txt (line 3)) (11.1.0)\n",
-      "Requirement already satisfied: pygame in ./.venv/lib/python3.13/site-packages (from -r requirements.txt (line 4)) (2.6.1)\n",
-      "Requirement already satisfied: jupyter in ./.venv/lib/python3.13/site-packages (from -r requirements.txt (line 5)) (1.1.1)\n",
-      "Requirement already satisfied: ipywidgets in ./.venv/lib/python3.13/site-packages (from -r requirements.txt (line 6)) (8.1.5)\n",
-      "Requirement already satisfied: notebook in ./.venv/lib/python3.13/site-packages (from jupyter->-r requirements.txt (line 5)) (7.3.2)\n",
-      "Requirement already satisfied: jupyter-console in ./.venv/lib/python3.13/site-packages (from jupyter->-r requirements.txt (line 5)) (6.6.3)\n",
-      "Requirement already satisfied: nbconvert in ./.venv/lib/python3.13/site-packages (from jupyter->-r requirements.txt (line 5)) (7.16.6)\n",
-      "Requirement already satisfied: ipykernel in ./.venv/lib/python3.13/site-packages (from jupyter->-r requirements.txt (line 5)) (6.29.5)\n",
-      "Requirement already satisfied: jupyterlab in ./.venv/lib/python3.13/site-packages (from jupyter->-r requirements.txt (line 5)) (4.3.5)\n",
-      "Requirement already satisfied: comm>=0.1.3 in ./.venv/lib/python3.13/site-packages (from ipywidgets->-r requirements.txt (line 6)) (0.2.2)\n",
-      "Requirement already satisfied: ipython>=6.1.0 in ./.venv/lib/python3.13/site-packages (from ipywidgets->-r requirements.txt (line 6)) (8.32.0)\n",
-      "Requirement already satisfied: traitlets>=4.3.1 in ./.venv/lib/python3.13/site-packages (from ipywidgets->-r requirements.txt (line 6)) (5.14.3)\n",
-      "Requirement already satisfied: widgetsnbextension~=4.0.12 in ./.venv/lib/python3.13/site-packages (from ipywidgets->-r requirements.txt (line 6)) (4.0.13)\n",
-      "Requirement already satisfied: jupyterlab-widgets~=3.0.12 in ./.venv/lib/python3.13/site-packages (from ipywidgets->-r requirements.txt (line 6)) (3.0.13)\n",
-      "Requirement already satisfied: decorator in ./.venv/lib/python3.13/site-packages (from ipython>=6.1.0->ipywidgets->-r requirements.txt (line 6)) (5.2.0)\n",
-      "Requirement already satisfied: jedi>=0.16 in ./.venv/lib/python3.13/site-packages (from ipython>=6.1.0->ipywidgets->-r requirements.txt (line 6)) (0.19.2)\n",
-      "Requirement already satisfied: matplotlib-inline in ./.venv/lib/python3.13/site-packages (from ipython>=6.1.0->ipywidgets->-r requirements.txt (line 6)) (0.1.7)\n",
-      "Requirement already satisfied: pexpect>4.3 in ./.venv/lib/python3.13/site-packages (from ipython>=6.1.0->ipywidgets->-r requirements.txt (line 6)) (4.9.0)\n",
-      "Requirement already satisfied: prompt_toolkit<3.1.0,>=3.0.41 in ./.venv/lib/python3.13/site-packages (from ipython>=6.1.0->ipywidgets->-r requirements.txt (line 6)) (3.0.50)\n",
-      "Requirement already satisfied: pygments>=2.4.0 in ./.venv/lib/python3.13/site-packages (from ipython>=6.1.0->ipywidgets->-r requirements.txt (line 6)) (2.19.1)\n",
-      "Requirement already satisfied: stack_data in ./.venv/lib/python3.13/site-packages (from ipython>=6.1.0->ipywidgets->-r requirements.txt (line 6)) (0.6.3)\n",
-      "Requirement already satisfied: appnope in ./.venv/lib/python3.13/site-packages (from ipykernel->jupyter->-r requirements.txt (line 5)) (0.1.4)\n",
-      "Requirement already satisfied: debugpy>=1.6.5 in ./.venv/lib/python3.13/site-packages (from ipykernel->jupyter->-r requirements.txt (line 5)) (1.8.12)\n",
-      "Requirement already satisfied: jupyter-client>=6.1.12 in ./.venv/lib/python3.13/site-packages (from ipykernel->jupyter->-r requirements.txt (line 5)) (8.6.3)\n",
-      "Requirement already satisfied: jupyter-core!=5.0.*,>=4.12 in ./.venv/lib/python3.13/site-packages (from ipykernel->jupyter->-r requirements.txt (line 5)) (5.7.2)\n",
-      "Requirement already satisfied: nest-asyncio in ./.venv/lib/python3.13/site-packages (from ipykernel->jupyter->-r requirements.txt (line 5)) (1.6.0)\n",
-      "Requirement already satisfied: packaging in ./.venv/lib/python3.13/site-packages (from ipykernel->jupyter->-r requirements.txt (line 5)) (24.2)\n",
-      "Requirement already satisfied: psutil in ./.venv/lib/python3.13/site-packages (from ipykernel->jupyter->-r requirements.txt (line 5)) (7.0.0)\n",
-      "Requirement already satisfied: pyzmq>=24 in ./.venv/lib/python3.13/site-packages (from ipykernel->jupyter->-r requirements.txt (line 5)) (26.2.1)\n",
-      "Requirement already satisfied: tornado>=6.1 in ./.venv/lib/python3.13/site-packages (from ipykernel->jupyter->-r requirements.txt (line 5)) (6.4.2)\n",
-      "Requirement already satisfied: async-lru>=1.0.0 in ./.venv/lib/python3.13/site-packages (from jupyterlab->jupyter->-r requirements.txt (line 5)) (2.0.4)\n",
-      "Requirement already satisfied: httpx>=0.25.0 in ./.venv/lib/python3.13/site-packages (from jupyterlab->jupyter->-r requirements.txt (line 5)) (0.28.1)\n",
-      "Requirement already satisfied: jinja2>=3.0.3 in ./.venv/lib/python3.13/site-packages (from jupyterlab->jupyter->-r requirements.txt (line 5)) (3.1.5)\n",
-      "Requirement already satisfied: jupyter-lsp>=2.0.0 in ./.venv/lib/python3.13/site-packages (from jupyterlab->jupyter->-r requirements.txt (line 5)) (2.2.5)\n",
-      "Requirement already satisfied: jupyter-server<3,>=2.4.0 in ./.venv/lib/python3.13/site-packages (from jupyterlab->jupyter->-r requirements.txt (line 5)) (2.15.0)\n",
-      "Requirement already satisfied: jupyterlab-server<3,>=2.27.1 in ./.venv/lib/python3.13/site-packages (from jupyterlab->jupyter->-r requirements.txt (line 5)) (2.27.3)\n",
-      "Requirement already satisfied: notebook-shim>=0.2 in ./.venv/lib/python3.13/site-packages (from jupyterlab->jupyter->-r requirements.txt (line 5)) (0.2.4)\n",
-      "Requirement already satisfied: setuptools>=40.8.0 in ./.venv/lib/python3.13/site-packages (from jupyterlab->jupyter->-r requirements.txt (line 5)) (75.8.0)\n",
-      "Requirement already satisfied: beautifulsoup4 in ./.venv/lib/python3.13/site-packages (from nbconvert->jupyter->-r requirements.txt (line 5)) (4.13.3)\n",
-      "Requirement already satisfied: bleach!=5.0.0 in ./.venv/lib/python3.13/site-packages (from bleach[css]!=5.0.0->nbconvert->jupyter->-r requirements.txt (line 5)) (6.2.0)\n",
-      "Requirement already satisfied: defusedxml in ./.venv/lib/python3.13/site-packages (from nbconvert->jupyter->-r requirements.txt (line 5)) (0.7.1)\n",
-      "Requirement already satisfied: jupyterlab-pygments in ./.venv/lib/python3.13/site-packages (from nbconvert->jupyter->-r requirements.txt (line 5)) (0.3.0)\n",
-      "Requirement already satisfied: markupsafe>=2.0 in ./.venv/lib/python3.13/site-packages (from nbconvert->jupyter->-r requirements.txt (line 5)) (3.0.2)\n",
-      "Requirement already satisfied: mistune<4,>=2.0.3 in ./.venv/lib/python3.13/site-packages (from nbconvert->jupyter->-r requirements.txt (line 5)) (3.1.2)\n",
-      "Requirement already satisfied: nbclient>=0.5.0 in ./.venv/lib/python3.13/site-packages (from nbconvert->jupyter->-r requirements.txt (line 5)) (0.10.2)\n",
-      "Requirement already satisfied: nbformat>=5.7 in ./.venv/lib/python3.13/site-packages (from nbconvert->jupyter->-r requirements.txt (line 5)) (5.10.4)\n",
-      "Requirement already satisfied: pandocfilters>=1.4.1 in ./.venv/lib/python3.13/site-packages (from nbconvert->jupyter->-r requirements.txt (line 5)) (1.5.1)\n",
-      "Requirement already satisfied: webencodings in ./.venv/lib/python3.13/site-packages (from bleach!=5.0.0->bleach[css]!=5.0.0->nbconvert->jupyter->-r requirements.txt (line 5)) (0.5.1)\n",
-      "Requirement already satisfied: tinycss2<1.5,>=1.1.0 in ./.venv/lib/python3.13/site-packages (from bleach[css]!=5.0.0->nbconvert->jupyter->-r requirements.txt (line 5)) (1.4.0)\n",
-      "Requirement already satisfied: anyio in ./.venv/lib/python3.13/site-packages (from httpx>=0.25.0->jupyterlab->jupyter->-r requirements.txt (line 5)) (4.8.0)\n",
-      "Requirement already satisfied: certifi in ./.venv/lib/python3.13/site-packages (from httpx>=0.25.0->jupyterlab->jupyter->-r requirements.txt (line 5)) (2025.1.31)\n",
-      "Requirement already satisfied: httpcore==1.* in ./.venv/lib/python3.13/site-packages (from httpx>=0.25.0->jupyterlab->jupyter->-r requirements.txt (line 5)) (1.0.7)\n",
-      "Requirement already satisfied: idna in ./.venv/lib/python3.13/site-packages (from httpx>=0.25.0->jupyterlab->jupyter->-r requirements.txt (line 5)) (3.10)\n",
-      "Requirement already satisfied: h11<0.15,>=0.13 in ./.venv/lib/python3.13/site-packages (from httpcore==1.*->httpx>=0.25.0->jupyterlab->jupyter->-r requirements.txt (line 5)) (0.14.0)\n",
-      "Requirement already satisfied: parso<0.9.0,>=0.8.4 in ./.venv/lib/python3.13/site-packages (from jedi>=0.16->ipython>=6.1.0->ipywidgets->-r requirements.txt (line 6)) (0.8.4)\n",
-      "Requirement already satisfied: python-dateutil>=2.8.2 in ./.venv/lib/python3.13/site-packages (from jupyter-client>=6.1.12->ipykernel->jupyter->-r requirements.txt (line 5)) (2.9.0.post0)\n",
-      "Requirement already satisfied: platformdirs>=2.5 in ./.venv/lib/python3.13/site-packages (from jupyter-core!=5.0.*,>=4.12->ipykernel->jupyter->-r requirements.txt (line 5)) (4.3.6)\n",
-      "Requirement already satisfied: argon2-cffi>=21.1 in ./.venv/lib/python3.13/site-packages (from jupyter-server<3,>=2.4.0->jupyterlab->jupyter->-r requirements.txt (line 5)) (23.1.0)\n",
-      "Requirement already satisfied: jupyter-events>=0.11.0 in ./.venv/lib/python3.13/site-packages (from jupyter-server<3,>=2.4.0->jupyterlab->jupyter->-r requirements.txt (line 5)) (0.12.0)\n",
-      "Requirement already satisfied: jupyter-server-terminals>=0.4.4 in ./.venv/lib/python3.13/site-packages (from jupyter-server<3,>=2.4.0->jupyterlab->jupyter->-r requirements.txt (line 5)) (0.5.3)\n",
-      "Requirement already satisfied: overrides>=5.0 in ./.venv/lib/python3.13/site-packages (from jupyter-server<3,>=2.4.0->jupyterlab->jupyter->-r requirements.txt (line 5)) (7.7.0)\n",
-      "Requirement already satisfied: prometheus-client>=0.9 in ./.venv/lib/python3.13/site-packages (from jupyter-server<3,>=2.4.0->jupyterlab->jupyter->-r requirements.txt (line 5)) (0.21.1)\n",
-      "Requirement already satisfied: send2trash>=1.8.2 in ./.venv/lib/python3.13/site-packages (from jupyter-server<3,>=2.4.0->jupyterlab->jupyter->-r requirements.txt (line 5)) (1.8.3)\n",
-      "Requirement already satisfied: terminado>=0.8.3 in ./.venv/lib/python3.13/site-packages (from jupyter-server<3,>=2.4.0->jupyterlab->jupyter->-r requirements.txt (line 5)) (0.18.1)\n",
-      "Requirement already satisfied: websocket-client>=1.7 in ./.venv/lib/python3.13/site-packages (from jupyter-server<3,>=2.4.0->jupyterlab->jupyter->-r requirements.txt (line 5)) (1.8.0)\n",
-      "Requirement already satisfied: babel>=2.10 in ./.venv/lib/python3.13/site-packages (from jupyterlab-server<3,>=2.27.1->jupyterlab->jupyter->-r requirements.txt (line 5)) (2.17.0)\n",
-      "Requirement already satisfied: json5>=0.9.0 in ./.venv/lib/python3.13/site-packages (from jupyterlab-server<3,>=2.27.1->jupyterlab->jupyter->-r requirements.txt (line 5)) (0.10.0)\n",
-      "Requirement already satisfied: jsonschema>=4.18.0 in ./.venv/lib/python3.13/site-packages (from jupyterlab-server<3,>=2.27.1->jupyterlab->jupyter->-r requirements.txt (line 5)) (4.23.0)\n",
-      "Requirement already satisfied: requests>=2.31 in ./.venv/lib/python3.13/site-packages (from jupyterlab-server<3,>=2.27.1->jupyterlab->jupyter->-r requirements.txt (line 5)) (2.32.3)\n",
-      "Requirement already satisfied: fastjsonschema>=2.15 in ./.venv/lib/python3.13/site-packages (from nbformat>=5.7->nbconvert->jupyter->-r requirements.txt (line 5)) (2.21.1)\n",
-      "Requirement already satisfied: ptyprocess>=0.5 in ./.venv/lib/python3.13/site-packages (from pexpect>4.3->ipython>=6.1.0->ipywidgets->-r requirements.txt (line 6)) (0.7.0)\n",
-      "Requirement already satisfied: wcwidth in ./.venv/lib/python3.13/site-packages (from prompt_toolkit<3.1.0,>=3.0.41->ipython>=6.1.0->ipywidgets->-r requirements.txt (line 6)) (0.2.13)\n",
-      "Requirement already satisfied: soupsieve>1.2 in ./.venv/lib/python3.13/site-packages (from beautifulsoup4->nbconvert->jupyter->-r requirements.txt (line 5)) (2.6)\n",
-      "Requirement already satisfied: typing-extensions>=4.0.0 in ./.venv/lib/python3.13/site-packages (from beautifulsoup4->nbconvert->jupyter->-r requirements.txt (line 5)) (4.12.2)\n",
-      "Requirement already satisfied: executing>=1.2.0 in ./.venv/lib/python3.13/site-packages (from stack_data->ipython>=6.1.0->ipywidgets->-r requirements.txt (line 6)) (2.2.0)\n",
-      "Requirement already satisfied: asttokens>=2.1.0 in ./.venv/lib/python3.13/site-packages (from stack_data->ipython>=6.1.0->ipywidgets->-r requirements.txt (line 6)) (3.0.0)\n",
-      "Requirement already satisfied: pure-eval in ./.venv/lib/python3.13/site-packages (from stack_data->ipython>=6.1.0->ipywidgets->-r requirements.txt (line 6)) (0.2.3)\n",
-      "Requirement already satisfied: sniffio>=1.1 in ./.venv/lib/python3.13/site-packages (from anyio->httpx>=0.25.0->jupyterlab->jupyter->-r requirements.txt (line 5)) (1.3.1)\n",
-      "Requirement already satisfied: argon2-cffi-bindings in ./.venv/lib/python3.13/site-packages (from argon2-cffi>=21.1->jupyter-server<3,>=2.4.0->jupyterlab->jupyter->-r requirements.txt (line 5)) (21.2.0)\n",
-      "Requirement already satisfied: attrs>=22.2.0 in ./.venv/lib/python3.13/site-packages (from jsonschema>=4.18.0->jupyterlab-server<3,>=2.27.1->jupyterlab->jupyter->-r requirements.txt (line 5)) (25.1.0)\n",
-      "Requirement already satisfied: jsonschema-specifications>=2023.03.6 in ./.venv/lib/python3.13/site-packages (from jsonschema>=4.18.0->jupyterlab-server<3,>=2.27.1->jupyterlab->jupyter->-r requirements.txt (line 5)) (2024.10.1)\n",
-      "Requirement already satisfied: referencing>=0.28.4 in ./.venv/lib/python3.13/site-packages (from jsonschema>=4.18.0->jupyterlab-server<3,>=2.27.1->jupyterlab->jupyter->-r requirements.txt (line 5)) (0.36.2)\n",
-      "Requirement already satisfied: rpds-py>=0.7.1 in ./.venv/lib/python3.13/site-packages (from jsonschema>=4.18.0->jupyterlab-server<3,>=2.27.1->jupyterlab->jupyter->-r requirements.txt (line 5)) (0.23.1)\n",
-      "Requirement already satisfied: python-json-logger>=2.0.4 in ./.venv/lib/python3.13/site-packages (from jupyter-events>=0.11.0->jupyter-server<3,>=2.4.0->jupyterlab->jupyter->-r requirements.txt (line 5)) (3.2.1)\n",
-      "Requirement already satisfied: pyyaml>=5.3 in ./.venv/lib/python3.13/site-packages (from jupyter-events>=0.11.0->jupyter-server<3,>=2.4.0->jupyterlab->jupyter->-r requirements.txt (line 5)) (6.0.2)\n",
-      "Requirement already satisfied: rfc3339-validator in ./.venv/lib/python3.13/site-packages (from jupyter-events>=0.11.0->jupyter-server<3,>=2.4.0->jupyterlab->jupyter->-r requirements.txt (line 5)) (0.1.4)\n",
-      "Requirement already satisfied: rfc3986-validator>=0.1.1 in ./.venv/lib/python3.13/site-packages (from jupyter-events>=0.11.0->jupyter-server<3,>=2.4.0->jupyterlab->jupyter->-r requirements.txt (line 5)) (0.1.1)\n",
-      "Requirement already satisfied: six>=1.5 in ./.venv/lib/python3.13/site-packages (from python-dateutil>=2.8.2->jupyter-client>=6.1.12->ipykernel->jupyter->-r requirements.txt (line 5)) (1.17.0)\n",
-      "Requirement already satisfied: charset-normalizer<4,>=2 in ./.venv/lib/python3.13/site-packages (from requests>=2.31->jupyterlab-server<3,>=2.27.1->jupyterlab->jupyter->-r requirements.txt (line 5)) (3.4.1)\n",
-      "Requirement already satisfied: urllib3<3,>=1.21.1 in ./.venv/lib/python3.13/site-packages (from requests>=2.31->jupyterlab-server<3,>=2.27.1->jupyterlab->jupyter->-r requirements.txt (line 5)) (2.3.0)\n",
-      "Requirement already satisfied: fqdn in ./.venv/lib/python3.13/site-packages (from jsonschema[format-nongpl]>=4.18.0->jupyter-events>=0.11.0->jupyter-server<3,>=2.4.0->jupyterlab->jupyter->-r requirements.txt (line 5)) (1.5.1)\n",
-      "Requirement already satisfied: isoduration in ./.venv/lib/python3.13/site-packages (from jsonschema[format-nongpl]>=4.18.0->jupyter-events>=0.11.0->jupyter-server<3,>=2.4.0->jupyterlab->jupyter->-r requirements.txt (line 5)) (20.11.0)\n",
-      "Requirement already satisfied: jsonpointer>1.13 in ./.venv/lib/python3.13/site-packages (from jsonschema[format-nongpl]>=4.18.0->jupyter-events>=0.11.0->jupyter-server<3,>=2.4.0->jupyterlab->jupyter->-r requirements.txt (line 5)) (3.0.0)\n",
-      "Requirement already satisfied: uri-template in ./.venv/lib/python3.13/site-packages (from jsonschema[format-nongpl]>=4.18.0->jupyter-events>=0.11.0->jupyter-server<3,>=2.4.0->jupyterlab->jupyter->-r requirements.txt (line 5)) (1.3.0)\n",
-      "Requirement already satisfied: webcolors>=24.6.0 in ./.venv/lib/python3.13/site-packages (from jsonschema[format-nongpl]>=4.18.0->jupyter-events>=0.11.0->jupyter-server<3,>=2.4.0->jupyterlab->jupyter->-r requirements.txt (line 5)) (24.11.1)\n",
-      "Requirement already satisfied: cffi>=1.0.1 in ./.venv/lib/python3.13/site-packages (from argon2-cffi-bindings->argon2-cffi>=21.1->jupyter-server<3,>=2.4.0->jupyterlab->jupyter->-r requirements.txt (line 5)) (1.17.1)\n",
-      "Requirement already satisfied: pycparser in ./.venv/lib/python3.13/site-packages (from cffi>=1.0.1->argon2-cffi-bindings->argon2-cffi>=21.1->jupyter-server<3,>=2.4.0->jupyterlab->jupyter->-r requirements.txt (line 5)) (2.22)\n",
-      "Requirement already satisfied: arrow>=0.15.0 in ./.venv/lib/python3.13/site-packages (from isoduration->jsonschema[format-nongpl]>=4.18.0->jupyter-events>=0.11.0->jupyter-server<3,>=2.4.0->jupyterlab->jupyter->-r requirements.txt (line 5)) (1.3.0)\n",
-      "Requirement already satisfied: types-python-dateutil>=2.8.10 in ./.venv/lib/python3.13/site-packages (from arrow>=0.15.0->isoduration->jsonschema[format-nongpl]>=4.18.0->jupyter-events>=0.11.0->jupyter-server<3,>=2.4.0->jupyterlab->jupyter->-r requirements.txt (line 5)) (2.9.0.20241206)\n",
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "%pip install -r requirements.txt"
+    "#%pip install -r requirements.txt"
    ]
   },
   {
@@ -151,7 +42,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 58,
    "metadata": {},
    "outputs": [
     {
@@ -207,11 +98,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 59,
    "metadata": {},
    "outputs": [],
    "source": [
-    "level_path = \"levels/BFSfriendly.lvl\"\n",
+    "level_path = \"levels/TwoAgentsDebug.lvl\"\n",
     "\n",
     "# for pure pathfinding problems\n",
     "action_library = DEFAULT_MAPF_ACTION_LIBRARY\n",
@@ -219,8 +110,8 @@
     "# for sokoban-like problems (includes Push and Pull actions)\n",
     "# action_library = DEFAULT_HOSPITAL_ACTION_LIBRARY\n",
     "\n",
-    "heuristic_name = \"goalcount\" # zero, goalcount, advanced\n",
-    "strategy_name = \"astar\" # bfs, dfs, astar, greedy, astarverbose, greedyverbose\n",
+    "heuristic_name = \"advanced\" # zero, goalcount, advanced\n",
+    "strategy_name = \"greedy\" # bfs, dfs, astar, greedy, astarverbose, greedyverbose\n",
     "n_trials = 1 # number of trials"
    ]
   },
@@ -235,7 +126,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 60,
    "metadata": {},
    "outputs": [
     {
@@ -243,18 +134,15 @@
      "output_type": "stream",
      "text": [
       "The initial state of the level is:\n",
-      "++++++++++++++++\n",
-      "+              +\n",
-      "+              +\n",
-      "+              +\n",
-      "+      01      +\n",
-      "+              +\n",
-      "+              +\n",
-      "+              +\n",
-      "++++++++++++++++\n",
+      "++++++\n",
+      "+0   +\n",
+      "+ 2  +\n",
+      "+1   +\n",
+      "+    +\n",
+      "++++++\n",
       "\n",
       "The goal description of the level is:\n",
-      "((3, 8), '0', True) and ((3, 9), '1', True)\n"
+      "((1, 4), '0', True) and ((4, 4), '1', True)\n"
      ]
     }
    ],
@@ -300,13 +188,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 61,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "acd688f9599d401b846e3cfa86038356",
+       "model_id": "a3ca4b05db3a4f5da3df783d2f329fad",
        "version_major": 2,
        "version_minor": 0
       },
@@ -337,7 +225,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 62,
    "metadata": {},
    "outputs": [
     {
@@ -345,9 +233,9 @@
      "output_type": "stream",
      "text": [
       "Number of trials: 1\n",
-      "Average solution length: 2.0\n",
+      "Average solution length: 10.0\n",
       "Solution length variance : 0.0\n",
-      "Average number of states generated: 3.0\n",
+      "Average number of states generated: 421.0\n",
       "Number of states generated variance : 0.0\n"
      ]
     }
@@ -370,32 +258,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 63,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "pygame 2.6.1 (SDL 2.28.4, Python 3.13.1)\n",
-      "Hello from the pygame community. https://www.pygame.org/contribute.html\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-02-23 18:19:29.239 Python[22878:638919] WARNING: Secure coding is automatically enabled for restorable state! However, not on all supported macOS versions of this application. Opt-in to secure coding explicitly by implementing NSApplicationDelegate.applicationSupportsSecureRestorableState:.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Finished executing the plan\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Select trial to render\n",
     "index_to_render = 0\n",
@@ -420,7 +285,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 64,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -438,7 +303,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "artificialIntelligence",
    "language": "python",
    "name": "python3"
   },
@@ -452,7 +317,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.1"
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,

--- a/searchclient/domains/hospital/heuristics.py
+++ b/searchclient/domains/hospital/heuristics.py
@@ -61,13 +61,36 @@ class HospitalGoalCountHeuristics:
 class HospitalAdvancedHeuristics:
 
     def __init__(self):
-        raise NotImplementedError()
+        self.goal_positions = []
 
     def preprocess(self, level: h_level.HospitalLevel):
         # This function will be called a single time prior to the search allowing us to preprocess the level such as
         # pre-computing lookup tables or other acceleration structures
-        raise NotImplementedError()
+        self.goal_positions = level.box_goals + level.agent_goals
 
     def h(self, state: h_state.HospitalState, goal_description: h_goal_description.HospitalGoalDescription) -> int:
         # your heuristic goes here...      
-        raise NotImplementedError()
+        totalDistance = 0
+
+        for goalPosition, goalChar, isPositiveLiteral in goal_description.goals:
+            char = state.object_at(goalPosition)
+            if isPositiveLiteral and goalChar == char:
+                continue
+            elif not isPositiveLiteral and goalChar != char:
+                continue
+            
+            #Calculating Manhattan distance
+            for boxPosition in state.box_positions:
+                if state.box_at(boxPosition) == goalChar:
+                    distance = abs(boxPosition[0] - goalPosition[0]) + abs(boxPosition[1] - goalPosition[1])
+                    totalDistance += distance
+                    break
+
+            for agentPosition in state.agent_positions:
+                if state.agent_at(agentPosition) == goalChar:
+                    distance = abs(agentPosition[0] - goalPosition[0]) + abs(agentPosition[1] - goalPosition[1])
+                    totalDistance += distance
+                    break
+
+        print(f"h(state): {totalDistance}")   
+        return totalDistance

--- a/searchclient/search_algorithms/graph_search.py
+++ b/searchclient/search_algorithms/graph_search.py
@@ -82,7 +82,7 @@ def graph_search(
 
         # Print the current state and frontier
         print(f"Current state: {node}")
-        print(f"Frontier: {[str(state) for state in frontier]}")
+        print(f"Frontier size: {frontier.size()}")
 
         if goal_description.is_goal(node):
             elapsed_time = time.time() - start_time  # Compute elapsed time
@@ -95,15 +95,21 @@ def graph_search(
 
             if child not in expandedNodes and not frontier.contains(child):
                 g = node.path_cost + 1
-                h = heuristic.h(child, goal_description)
-                f = g + h
                 
-                print(f"f(child): {f}, g(child): {g}, h(child): {h}")
-
-                heuristicValues[child] = (f, g, h) #Storing heuristic values
+                # for informed search frontiers, get the heuristic value
+                if hasattr(frontier, 'heuristic'):
+                    h = frontier.heuristic.h(child, goal_description)
+                    f = g + h
+                    print(f"f(child): {f}, g(child): {g}, h(child): {h}")
+                    heuristicValues[child] = (f, g, h) #Storing heuristic values
+                else:
+                    #for uninformed search, we don't need heuristic values
+                    print(f"g(child): {g}")
+                    heuristicValues[child] = (g, g, 0)
+                
                 frontier.add(child)  # Add child to the frontier
 
-        print_search_status(expandedNodes, heuristicValues, frontier)
+        print_search_status(expandedNodes, frontier, heuristicValues)
 
     elapsed_time = time.time() - start_time  # Compute elapsed time
     return False, [], iterations, elapsed_time  # Return failure if no solution is found


### PR DESCRIPTION
## Fix TypeError in graph_search algorithm
### Problem
When running the search algorithm with a FrontierGreedy object, the code was throwing a TypeError: 'FrontierGreedy' object is not iterable. This occurred because the graph_search function was attempting to iterate over the frontier object in a print statement, but the frontier classes don't implement the __iter__ method.
### Changes Made
- Fixed the TypeError by removing the attempt to iterate over the frontier object
- Changed the frontier display to show size instead of listing all states
- Improved heuristic handling to work properly with both informed and uninformed search strategies
- Added conditional logic to use the frontier's heuristic when available instead of directly importing a specific heuristic
### Testing
The changes have been tested with search tester jupyter notebook and works without issue
